### PR TITLE
Apply minimal changes needed for PyPI installation

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,6 +43,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        install-mode:
+          - dev
+          - standard
         python-version:
           - "3.8"
           - "3.9"
@@ -51,9 +54,6 @@ jobs:
         os:
           - linux
           - win64
-        install-mode:
-          - dev
-          # - standard
         include:
           - os: linux
             os-version: ubuntu-22.04

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dependencies = [
     "pyyaml",
     # both idaes-pse and watertap should be removed from core dependencies ASAP
     "idaes-pse",  # idaes.core.surrogate.pysmo.sampling
-    "watertap >= 1.0.dev0",  # watertap.core.solvers.get_solver()
+    "watertap",   # watertap.core.solvers.get_solver() (after watertap-org/watertap#1353)
+                  # or imported to apply WaterTAP solver settings (0.12.0 or earlier)
 ]
 [project.optional-dependencies]
 ray = [
@@ -28,6 +29,7 @@ mpi = [
 testing = [
     "pytest >= 8",
     "idaes-pse",  # for IDAES solvers
+    "watertap",   # loop_tool tests
     "requests",  # for src/parameter_sweep/tests/test_parameter_sweep.py
 ]
 [tool.setuptools_scm]

--- a/src/parameter_sweep/_compat.py
+++ b/src/parameter_sweep/_compat.py
@@ -2,11 +2,11 @@
 Internal utility module for utility functions needed for compatibility, none of which should be needed long-term.
 """
 
-
 try:
     from watertap.core.solvers import get_solver
 except AttributeError:
     # prior to watertap-org/watertap#1353, using get_solver() from IDAES
     from idaes.core.solvers import get_solver
-    # and then importing watertap to override the IDAES solver with the WaterTAP settings 
+
+    # and then importing watertap to override the IDAES solver with the WaterTAP settings
     import watertap

--- a/src/parameter_sweep/_compat.py
+++ b/src/parameter_sweep/_compat.py
@@ -1,0 +1,12 @@
+"""
+Internal utility module for utility functions needed for compatibility, none of which should be needed long-term.
+"""
+
+
+try:
+    from watertap.core.solvers import get_solver
+except AttributeError:
+    # prior to watertap-org/watertap#1353, using get_solver() from IDAES
+    from idaes.core.solvers import get_solver
+    # and then importing watertap to override the IDAES solver with the WaterTAP settings 
+    import watertap

--- a/src/parameter_sweep/_compat.py
+++ b/src/parameter_sweep/_compat.py
@@ -4,7 +4,7 @@ Internal utility module for utility functions needed for compatibility, none of 
 
 try:
     from watertap.core.solvers import get_solver
-except AttributeError:
+except ModuleNotFoundError:
     # prior to watertap-org/watertap#1353, using get_solver() from IDAES
     from idaes.core.solvers import get_solver
 

--- a/src/parameter_sweep/loop_tool/loop_tool.py
+++ b/src/parameter_sweep/loop_tool/loop_tool.py
@@ -10,8 +10,6 @@
 # "https://github.com/watertap-org/watertap/"
 #################################################################################
 
-from watertap.core.solvers import get_solver
-
 from parameter_sweep import ParameterSweep, DifferentialParameterSweep
 from parameter_sweep import ParameterSweepReader
 from parameter_sweep.loop_tool.data_merging_tool import *
@@ -19,6 +17,7 @@ from parameter_sweep.parallel.parallel_manager_factory import (
     has_mpi_peer_processes,
     get_mpi_comm_process,
 )
+from parameter_sweep._compat import get_solver
 import copy
 import os
 import h5py

--- a/src/parameter_sweep/loop_tool/tests/ro_setup.py
+++ b/src/parameter_sweep/loop_tool/tests/ro_setup.py
@@ -20,7 +20,6 @@ from parameter_sweep.reader import ParameterSweepReader
 from parameter_sweep.differential import (
     DifferentialParameterSweep,
 )
-from watertap.core.solvers import get_solver
 import os
 
 __author__ = "Alexander V. Dudchenko (SLAC)"

--- a/src/parameter_sweep/parameter_sweep.py
+++ b/src/parameter_sweep/parameter_sweep.py
@@ -16,7 +16,6 @@ import copy
 import time
 
 from abc import abstractmethod, ABC
-from watertap.core.solvers import get_solver
 
 from idaes.core.surrogate.pysmo import sampling
 from pyomo.common.deprecation import deprecation_warning
@@ -42,6 +41,7 @@ from parameter_sweep.parallel_utils import (
     _ParameterSweepParallelUtils,
     return_none,
 )
+from parameter_sweep._compat import get_solver
 
 
 def _default_optimize(model, options=None, tee=False):


### PR DESCRIPTION
- Change `watertap >= 1.0.dev0` requirement to `watertap` since 1.0.x not yet available on PyPI
- Add `parameter_sweep._compat` module allowing to import `get_solver` flexibly for different WaterTAP versions