### PR TITLE
Remove watertap from required dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,7 @@ dependencies = [
     "h5py",
     "pyyaml",
     # both idaes-pse and watertap should be removed from core dependencies ASAP
-    "idaes-pse",  # idaes.core.surrogate.pysmo.sampling
-    "watertap",   # watertap.core.solvers.get_solver() (after watertap-org/watertap#1353)
-                  # or imported to apply WaterTAP solver settings (0.12.0 or earlier)
+    "idaes-pse",  # idaes.core.solvers.get_solver(), idaes.core.surrogate.pysmo.sampling
 ]
 [project.optional-dependencies]
 ray = [

--- a/src/parameter_sweep/_compat.py
+++ b/src/parameter_sweep/_compat.py
@@ -5,8 +5,6 @@ Internal utility module for utility functions needed for compatibility, none of 
 try:
     from watertap.core.solvers import get_solver
 except ModuleNotFoundError:
-    # prior to watertap-org/watertap#1353, using get_solver() from IDAES
+    # either watertap is not installed, or is a version prior to watertap-org/watertap#1353
+    # in either case, we use get_solver() from IDAES
     from idaes.core.solvers import get_solver
-
-    # and then importing watertap to override the IDAES solver with the WaterTAP settings
-    import watertap

--- a/src/parameter_sweep/loop_tool/tests/test_loop_tool.py
+++ b/src/parameter_sweep/loop_tool/tests/test_loop_tool.py
@@ -21,7 +21,10 @@ from parameter_sweep.parallel.parallel_manager_factory import (
     get_mpi_comm_process,
 )
 
-ro_setup = pytest.importorskip("parameter_sweep.loop_tool.tests.ro_setup", reason="ro_setup dependencies (typically watertap) not available")
+ro_setup = pytest.importorskip(
+    "parameter_sweep.loop_tool.tests.ro_setup",
+    reason="ro_setup dependencies (typically watertap) not available",
+)
 
 __author__ = "Alexander V. Dudchenko (SLAC)"
 

--- a/src/parameter_sweep/loop_tool/tests/test_loop_tool.py
+++ b/src/parameter_sweep/loop_tool/tests/test_loop_tool.py
@@ -12,16 +12,16 @@
 import pytest
 import os
 import numpy as np
-
-from parameter_sweep.loop_tool.tests import ro_setup
-from parameter_sweep.loop_tool.loop_tool import loopTool, get_working_dir
-import yaml
 import h5py
+import yaml
 
+from parameter_sweep.loop_tool.loop_tool import loopTool, get_working_dir
 from parameter_sweep.parallel.parallel_manager_factory import (
     has_mpi_peer_processes,
     get_mpi_comm_process,
 )
+
+ro_setup = pytest.importorskip("parameter_sweep.loop_tool.tests.ro_setup", reason="ro_setup dependencies (typically watertap) not available")
 
 __author__ = "Alexander V. Dudchenko (SLAC)"
 

--- a/src/parameter_sweep/parallel/MPI/__init__.py
+++ b/src/parameter_sweep/parallel/MPI/__init__.py
@@ -1,0 +1,16 @@
+#################################################################################
+# WaterTAP Copyright (c) 2020-2024, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory, Oak Ridge National Laboratory,
+# National Renewable Energy Laboratory, and National Energy Technology
+# Laboratory (subject to receipt of any required approvals from the U.S. Dept.
+# of Energy). All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and license
+# information, respectively. These files are also available online at the URL
+# "https://github.com/watertap-org/watertap/"
+#################################################################################
+
+try:
+    from mpi4py.MPI import *
+except ImportError:
+    from .dummy_mpi import DummyCOMM as COMM_WORLD

--- a/src/parameter_sweep/parallel/MPI/dummy_mpi.py
+++ b/src/parameter_sweep/parallel/MPI/dummy_mpi.py
@@ -1,0 +1,53 @@
+#################################################################################
+# WaterTAP Copyright (c) 2020-2024, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory, Oak Ridge National Laboratory,
+# National Renewable Energy Laboratory, and National Energy Technology
+# Laboratory (subject to receipt of any required approvals from the U.S. Dept.
+# of Energy). All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and license
+# information, respectively. These files are also available online at the URL
+# "https://github.com/watertap-org/watertap/"
+#################################################################################
+import numpy as np
+
+
+class DummyCOMM:
+
+    rank = 0
+    size = 1
+
+    @staticmethod
+    def Get_rank():
+        return 0
+
+    @staticmethod
+    def Get_size():
+        return 1
+
+    @staticmethod
+    def Barrier():
+        pass
+
+    @staticmethod
+    def Bcast(array, root=0):
+        pass
+
+    @staticmethod
+    def bcast(array, root=0):
+        return array
+
+    @staticmethod
+    def allgather(value):
+        return [value]
+
+    @staticmethod
+    def Gatherv(sendbuf=None, recvbuf=(None, None), root=0):
+        assert len(recvbuf) == 2
+        assert isinstance(recvbuf, tuple)
+        receive_arr = recvbuf[0]
+        receive_sizes = recvbuf[1]
+
+        assert isinstance(receive_arr, (np.ndarray, list))
+        assert len(receive_arr) == sum(receive_sizes)
+        receive_arr[:] = sendbuf[:]

--- a/src/parameter_sweep/parallel/MPI/tests/test_dummy_mpi.py
+++ b/src/parameter_sweep/parallel/MPI/tests/test_dummy_mpi.py
@@ -1,0 +1,37 @@
+#################################################################################
+# WaterTAP Copyright (c) 2020-2024, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory, Oak Ridge National Laboratory,
+# National Renewable Energy Laboratory, and National Energy Technology
+# Laboratory (subject to receipt of any required approvals from the U.S. Dept.
+# of Energy). All rights reserved.
+#
+# Please see the files COPYRIGHT.md and LICENSE.md for full copyright and license
+# information, respectively. These files are also available online at the URL
+# "https://github.com/watertap-org/watertap/"
+#################################################################################
+
+import pytest
+import numpy as np
+from parameter_sweep.parallel.MPI.dummy_mpi import DummyCOMM
+
+
+@pytest.mark.integration
+def test_dummy_mpi():
+    comm = DummyCOMM
+    rank = comm.Get_rank()
+    size = comm.Get_size()
+
+    n_arr = 3
+    dummy_array1 = np.arange(n_arr)
+    comm.Bcast(dummy_array1)
+    returned_array = comm.bcast(dummy_array1)
+    returned_list = comm.allgather(dummy_array1)
+    recvbuf = (np.zeros(n_arr), [n_arr])
+    comm.Gatherv(sendbuf=dummy_array1, recvbuf=recvbuf, root=0)
+
+    assert comm is DummyCOMM
+    assert rank == 0
+    assert size == 1
+    assert returned_array is dummy_array1
+    assert returned_list == [dummy_array1]
+    assert (recvbuf[0] == dummy_array1).all

--- a/src/parameter_sweep/parameter_sweep.py
+++ b/src/parameter_sweep/parameter_sweep.py
@@ -314,7 +314,7 @@ class _ParameterSweepBase(ABC):
             return
 
         if not requests_available:
-            raise ImportError(
+            raise RuntimeError(
                 "requests (parameter_sweep optional dependency) not installed"
             )
 

--- a/src/parameter_sweep/parameter_sweep.py
+++ b/src/parameter_sweep/parameter_sweep.py
@@ -310,20 +310,22 @@ class _ParameterSweepBase(ABC):
                 outputs[output_name] = exprs[output_name]
 
     def _publish_updates(self, iteration, solve_status, solve_time):
+        if not self.config.publish_progress:
+            return
+
         if not requests_available:
             raise ImportError(
                 "requests (parameter_sweep optional dependency) not installed"
             )
 
-        if self.config.publish_progress:
-            publish_dict = {
-                "worker_number": self.parallel_manager.get_rank(),
-                "iteration": iteration,
-                "solve_status": solve_status,
-                "solve_time": solve_time,
-            }
+        publish_dict = {
+            "worker_number": self.parallel_manager.get_rank(),
+            "iteration": iteration,
+            "solve_status": solve_status,
+            "solve_time": solve_time,
+        }
 
-            return requests.put(self.config.publish_address, data=publish_dict)
+        return requests.put(self.config.publish_address, data=publish_dict)
 
     def _create_global_combo_array(self, d, sampling_type):
         num_var_params = len(d)

--- a/src/parameter_sweep/tests/test_differential_parameter_sweep.py
+++ b/src/parameter_sweep/tests/test_differential_parameter_sweep.py
@@ -35,7 +35,7 @@ from parameter_sweep.tests.test_parameter_sweep import (
     build_model,
     build_sweep_params_for_tps,
 )
-import watertap.tools.MPI as MPI
+from parameter_sweep.parallel import MPI
 
 from parameter_sweep.model_manager import ModelManager
 

--- a/src/parameter_sweep/tests/test_parameter_sweep.py
+++ b/src/parameter_sweep/tests/test_parameter_sweep.py
@@ -21,7 +21,7 @@ from parameter_sweep.sampling_types import *
 from parameter_sweep import ParameterSweep, parameter_sweep
 from parameter_sweep.writer import *
 
-import watertap.tools.MPI as MPI
+from parameter_sweep.parallel import MPI
 from parameter_sweep.parallel.parallel_manager_factory import has_mpi_peer_processes
 
 # -----------------------------------------------------------------------------

--- a/src/parameter_sweep/tests/test_recursive_parameter_sweep.py
+++ b/src/parameter_sweep/tests/test_recursive_parameter_sweep.py
@@ -30,7 +30,7 @@ from parameter_sweep.tests.test_parameter_sweep import (
     _assert_dictionary_correctness,
 )
 
-import watertap.tools.MPI as MPI
+from parameter_sweep.parallel import MPI
 
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
- Add back MPI compatibility code that was left over during migration
- Modify `parameter_sweep._compat` so that `get_solver()` (from IDAES) is available even if `watertap` is not
  - The previous solution had an `import watertap` after the IDAES `get_solver()` import
  - This was to account for cases where `watertap` was available, but didn't have its own `get_solver()` implementation
  - However, this meant that the logic wouldn't work if only `idaes`, but not `watertap`, could be imported
  - The version proposed in this PR should now work in all cases:
    - If `watertap.core.solvers` exists: use `get_solver()` from WaterTAP
    - If `watertap` is not available, but IDAES is: use `get_solver()` from IDAES
    - If `watertap` is available, but doesn't have its own `get_solver()` (i.e. WaterTAP version preceeding watertap-org/watertap#1353): use `get_solver()` from IDAES, counting on the fact that the client code will import `watertap`, and therefore the global implicit WaterTAP solver settings will be applied to the solver returned by IDAES's `get_solver()`
- Add `pytest.importorskip()` for tests that use other `watertap` imports