### PR TITLE
Update ParameterSweep and RecursiveParameterSweep tests to stop using the deprecated API

### DIFF
--- a/src/parameter_sweep/tests/test_differential_parameter_sweep.py
+++ b/src/parameter_sweep/tests/test_differential_parameter_sweep.py
@@ -208,7 +208,7 @@ def test_create_differential_sweep_params_percentile(model):
 
 
 @pytest.mark.component
-def test_bad_differential_sweep_specs(model, tmp_path):
+def test_bad_differential_sweep_specs(model):
     m = model
     differential_sweep_specs = {
         "fs.b": {

--- a/src/parameter_sweep/tests/test_parameter_sweep.py
+++ b/src/parameter_sweep/tests/test_parameter_sweep.py
@@ -657,11 +657,6 @@ class TestParameterSweep:
             "input_a": (m.fs.input["a"], 0.1, 0.9, 3),
             "input_b": (m.fs.input["b"], 0.0, 0.5, 3),
         }
-        # outputs = {
-        #     "output_c": m.fs.output["c"],
-        #     "output_d": m.fs.output["d"],
-        #     "performance": m.fs.performance,
-        # }
 
         sweep_params, sampling_type = ps._process_sweep_params(sweep_params)
         values = ps._build_combinations(sweep_params, sampling_type, None)
@@ -760,11 +755,6 @@ class TestParameterSweep:
         sweep_params = {
             "input_a": NormalSample(m.fs.input["a"], 0.1, 0.9, global_num_cases),
             "input_b": NormalSample(m.fs.input["b"], 0.0, 0.5, global_num_cases),
-        }
-        outputs = {
-            "output_c": m.fs.output["c"],
-            "output_d": m.fs.output["d"],
-            "performance": m.fs.performance,
         }
 
         sweep_params, sampling_type = ps._process_sweep_params(sweep_params)
@@ -975,7 +965,7 @@ class TestParameterSweep:
 
     @pytest.mark.requires_idaes_solver
     @pytest.mark.component
-    def test_parameter_sweep_optimize(self, model, tmp_path):
+    def test_parameter_sweep_optimize(self, tmp_path):
         comm = MPI.COMM_WORLD
 
         tmp_path = _get_rank0_path(comm, tmp_path)
@@ -1106,7 +1096,7 @@ class TestParameterSweep:
             _assert_h5_csv_agreement(csv_results_file_name, read_dict)
 
     @pytest.mark.component
-    def test_parameter_sweep_optimize_with_added_var(self, model, tmp_path):
+    def test_parameter_sweep_optimize_with_added_var(self, tmp_path):
         # this will run a solve function that adds a variable but only in some
         # of the solves.
         """THIS TEST IS DESIGNED FOR 2 Parallel workers!!!!!!"""
@@ -1205,7 +1195,7 @@ class TestParameterSweep:
             _assert_dictionary_correctness(truth_dict, read_dict, rtol=1e-2)
 
     @pytest.mark.component
-    def test_parameter_sweep_bad_initialize_call_2(self, model, tmp_path):
+    def test_parameter_sweep_bad_initialize_call_2(self, tmp_path):
         comm = MPI.COMM_WORLD
 
         tmp_path = _get_rank0_path(comm, tmp_path)
@@ -1232,7 +1222,7 @@ class TestParameterSweep:
             )
 
     @pytest.mark.component
-    def test_parameter_sweep_recover(self, model, tmp_path):
+    def test_parameter_sweep_recover(self, tmp_path):
         comm = MPI.COMM_WORLD
 
         tmp_path = _get_rank0_path(comm, tmp_path)
@@ -1447,7 +1437,7 @@ class TestParameterSweep:
             _assert_h5_csv_agreement(csv_results_file_name, read_dict)
 
     @pytest.mark.component
-    def test_parameter_sweep_bad_recover(self, model, tmp_path):
+    def test_parameter_sweep_bad_recover(self, tmp_path):
         comm = MPI.COMM_WORLD
 
         tmp_path = _get_rank0_path(comm, tmp_path)
@@ -1633,7 +1623,7 @@ class TestParameterSweep:
             _assert_h5_csv_agreement(csv_results_file_name, read_dict)
 
     @pytest.mark.component
-    def test_parameter_sweep_force_initialize(self, model, tmp_path):
+    def test_parameter_sweep_force_initialize(self, tmp_path):
         results_fname = os.path.join(tmp_path, "global_results_force_initialize")
         csv_results_file_name = str(results_fname) + ".csv"
         h5_results_file_name = str(results_fname) + ".h5"
@@ -1877,7 +1867,7 @@ class TestParameterSweep:
             )
 
     @pytest.mark.component
-    def test_parameter_sweep_bad_reinitialize_call(self, model):
+    def test_parameter_sweep_bad_reinitialize_call(self):
         def reinit(a=42):
             pass
 

--- a/src/parameter_sweep/tests/test_parameter_sweep.py
+++ b/src/parameter_sweep/tests/test_parameter_sweep.py
@@ -993,28 +993,19 @@ class TestParameterSweep:
             interpolate_nan_outputs=True,
         )
 
-        m = model
-        m.fs.slack_penalty = 1000.0
-        m.fs.slack.setub(0)
-
-        A = m.fs.input["a"]
-        B = m.fs.input["b"]
-        sweep_params = {A.name: (A, 0.1, 0.9, 3), B.name: (B, 0.0, 0.5, 3)}
-        outputs = {
-            "output_c": m.fs.output["c"],
-            "output_d": m.fs.output["d"],
-            "performance": m.fs.performance,
-            "objective": m.objective,
-        }
-        results_fname = os.path.join(tmp_path, "global_results")
-        csv_results_file_name = str(results_fname) + ".csv"
-        h5_results_file_name = str(results_fname) + ".h5"
-
         # Call the parameter_sweep function
-        ps.parameter_sweep(
-            m,
-            sweep_params,
-            build_outputs=outputs,
+        _ = ps.parameter_sweep(
+            build_model_for_tps,
+            build_sweep_params_for_tps,
+            build_outputs=build_outputs_for_tps,
+            build_outputs_kwargs={
+                "output_keys": {
+                    "output_c": "fs.output[c]",
+                    "output_d": "fs.output[d]",
+                    "performance": "fs.performance",
+                    "objective": "objective",
+                }
+            },
         )
 
         # NOTE: rank 0 "owns" tmp_path, so it needs to be
@@ -1141,10 +1132,6 @@ class TestParameterSweep:
             parallel_back_end="MultiProcessing",
         )
 
-        results_fname = os.path.join(tmp_path, "global_results")
-        csv_results_file_name = str(results_fname) + ".csv"
-        h5_results_file_name = str(results_fname) + ".h5"
-
         # Call the parameter_sweep function
         ps.parameter_sweep(
             build_model_for_tps,
@@ -1236,21 +1223,14 @@ class TestParameterSweep:
             interpolate_nan_outputs=True,
         )
 
-        m = model
-        m.fs.slack_penalty = 1000.0
-        m.fs.slack.setub(0)
-
-        A = m.fs.input["a"]
-        B = m.fs.input["b"]
-        sweep_params = {A.name: (A, 0.1, 0.9, 3), B.name: (B, 0.0, 0.5, 3)}
-
         with pytest.raises(TypeError):
             # Call the parameter_sweep function
             _ = ps.parameter_sweep(
-                m,
-                sweep_params,
+                build_model_for_tps,
+                build_sweep_params_for_tps,
                 build_outputs=None,
             )
+
 
     @pytest.mark.component
     def test_parameter_sweep_recover(self, model, tmp_path):
@@ -1908,8 +1888,8 @@ class TestParameterSweep:
         with pytest.raises(TypeError):
             # Call the parameter_sweep function
             ps.parameter_sweep(
-                m,
-                sweep_params,
+                build_model_for_tps,
+                build_sweep_params_for_tps,
                 build_outputs=None,
             )
 
@@ -1942,7 +1922,7 @@ class TestParameterSweep:
             )
 
     @pytest.mark.component
-    def test_parameter_sweep_probe_fail(self, model, tmp_path):
+    def test_parameter_sweep_probe_fail(self, tmp_path):
         comm = MPI.COMM_WORLD
 
         tmp_path = _get_rank0_path(comm, tmp_path)

--- a/src/parameter_sweep/tests/test_parameter_sweep.py
+++ b/src/parameter_sweep/tests/test_parameter_sweep.py
@@ -1231,7 +1231,6 @@ class TestParameterSweep:
                 build_outputs=None,
             )
 
-
     @pytest.mark.component
     def test_parameter_sweep_recover(self, model, tmp_path):
         comm = MPI.COMM_WORLD

--- a/src/parameter_sweep/tests/test_parameter_sweep.py
+++ b/src/parameter_sweep/tests/test_parameter_sweep.py
@@ -1845,7 +1845,7 @@ class TestParameterSweep:
             _assert_h5_csv_agreement(csv_results_file_name, read_dict)
 
     @pytest.mark.component
-    def test_parameter_sweep_bad_sweep_update_before_initialize(self, model, tmp_path):
+    def test_parameter_sweep_bad_sweep_update_before_initialize(self):
         ps = ParameterSweep(
             optimize_function=_optimization,
             initialize_before_sweep=True,
@@ -1853,36 +1853,20 @@ class TestParameterSweep:
             initialize_kwargs=None,
             update_sweep_params_before_init=True,
         )
-        m = model
-        m.fs.slack_penalty = 1000.0
-        m.fs.slack.setub(0)
-
-        A = m.fs.input["a"]
-        B = m.fs.input["b"]
-        sweep_params = {A.name: (A, 0.1, 0.9, 3), B.name: (B, 0.0, 0.5, 3)}
 
         with pytest.raises(ValueError):
-            # Call the parameter_sweep function
             ps.parameter_sweep(
-                m,
-                sweep_params,
+                build_model_for_tps,
+                build_sweep_params_for_tps,
                 build_outputs=None,
             )
 
     @pytest.mark.component
-    def test_parameter_sweep_bad_optimization_call(self, model, tmp_path):
+    def test_parameter_sweep_bad_optimization_call(self):
         ps = ParameterSweep(
             optimize_function=_optimization,
             optimize_kwargs={"foo": "bar"},
         )
-
-        m = model
-        m.fs.slack_penalty = 1000.0
-        m.fs.slack.setub(0)
-
-        A = m.fs.input["a"]
-        B = m.fs.input["b"]
-        sweep_params = {A.name: (A, 0.1, 0.9, 3), B.name: (B, 0.0, 0.5, 3)}
 
         with pytest.raises(TypeError):
             # Call the parameter_sweep function
@@ -1893,7 +1877,7 @@ class TestParameterSweep:
             )
 
     @pytest.mark.component
-    def test_parameter_sweep_bad_reinitialize_call(self, model, tmp_path):
+    def test_parameter_sweep_bad_reinitialize_call(self, model):
         def reinit(a=42):
             pass
 
@@ -1904,19 +1888,11 @@ class TestParameterSweep:
             initialize_kwargs={"foo": "bar"},
         )
 
-        m = model
-        m.fs.slack_penalty = 1000.0
-        m.fs.slack.setub(0)
-
-        A = m.fs.input["a"]
-        B = m.fs.input["b"]
-        sweep_params = {A.name: (A, 0.1, 0.9, 3), B.name: (B, 0.0, 0.5, 3)}
-
         with pytest.raises(TypeError):
             # Call the parameter_sweep function
             ps.parameter_sweep(
-                m,
-                sweep_params,
+                build_model_for_tps,
+                build_sweep_params_for_tps,
                 build_outputs=None,
             )
 

--- a/src/parameter_sweep/tests/test_parameter_sweep_writer.py
+++ b/src/parameter_sweep/tests/test_parameter_sweep_writer.py
@@ -15,9 +15,10 @@ import os
 import numpy as np
 import pyomo.environ as pyo
 import copy
+import h5py
 
-from parameter_sweep.parameter_sweep import *
-from parameter_sweep.writer import *
+from parameter_sweep import ParameterSweep
+from parameter_sweep.writer import ParameterSweepWriter
 from parameter_sweep.tests.test_parameter_sweep import (
     _get_rank0_path,
     _read_output_h5,

--- a/src/parameter_sweep/tests/test_recursive_parameter_sweep.py
+++ b/src/parameter_sweep/tests/test_recursive_parameter_sweep.py
@@ -176,7 +176,7 @@ def test_aggregate_filtered_input_arr():
 
 
 @pytest.mark.component
-def test_recursive_parameter_sweep(model, tmp_path):
+def test_recursive_parameter_sweep(tmp_path):
     comm = MPI.COMM_WORLD
 
     tmp_path = _get_rank0_path(comm, tmp_path)

--- a/src/parameter_sweep/tests/test_recursive_parameter_sweep.py
+++ b/src/parameter_sweep/tests/test_recursive_parameter_sweep.py
@@ -35,8 +35,7 @@ from parameter_sweep.parallel import MPI
 # -----------------------------------------------------------------------------
 
 
-@pytest.fixture
-def model():
+def build_model():
     """
     # Example Usage:
     # Set the number of trials
@@ -77,6 +76,25 @@ def model():
     m.fs.pos = pyo.Constraint(expr=m.fs.x >= 0.0)
 
     return m
+
+
+def build_sweep_params(m):
+    num_samples = 10
+    sweep_params = {}
+    sweep_params["a_val"] = UniformSample(m.fs.a, 0.0, 1.0, num_samples)
+    return sweep_params
+
+
+def build_outputs(model):
+    outputs = {}
+    outputs["x_val"] = model.find_component("fs.x")
+
+    return outputs
+
+
+@pytest.fixture
+def model():
+    return build_model()
 
 
 @pytest.mark.component
@@ -173,26 +191,14 @@ def test_recursive_parameter_sweep(model, tmp_path):
         debugging_data_dir=tmp_path,
     )
 
-    m = model
-
-    solver = pyo.SolverFactory("ipopt")
-
     num_samples = 10
-    sweep_params = {}
-    sweep_params["a_val"] = UniformSample(m.fs.a, 0.0, 1.0, num_samples)
 
-    outputs = {}
-    outputs["x_val"] = m.fs.x
-
-    # Run the parameter sweep study using num_samples randomly drawn from the above range
-
+    # Run the parameter sweep using num_samples randomly drawn from the above range
     seed = 0
-
-    # Run the parameter sweep
     data_array, results_dict = ps.parameter_sweep(
-        m,
-        sweep_params,
-        build_outputs=outputs,
+        build_model=build_model,
+        build_sweep_params=build_sweep_params,
+        build_outputs=build_outputs,
         num_samples=num_samples,
         seed=seed,
     )
@@ -212,10 +218,7 @@ def test_recursive_parameter_sweep(model, tmp_path):
         ]
     )
 
-    import pprint
-
-    # print("data = ")
-    # pprint.pprint(data)
+    m = build_model()
     assert np.shape(data_array) == (10, 2)
     assert np.allclose(reference_save_data, data_array, equal_nan=True)
     assert np.allclose(np.sum(data_array, axis=1), value(m.fs.success_prob))


### PR DESCRIPTION
The ability to pass a Pyomo model and sweep params & output dictionaries was deprecated in parameter sweep a while back. However the tests continued to use it. This PR ensures all but the parameter sweep function tests are using the newer API. 