### PR TITLE
Add deprecation warnings for parameter sweep wrapper functions

### DIFF
--- a/src/parameter_sweep/functions.py
+++ b/src/parameter_sweep/functions.py
@@ -10,6 +10,8 @@
 # "https://github.com/watertap-org/watertap/"
 #################################################################################
 
+from pyomo.common.deprecation import deprecation_warning
+
 from parameter_sweep.parameter_sweep import (
     ParameterSweep,
     RecursiveParameterSweep,
@@ -137,6 +139,11 @@ def parameter_sweep(
         by ``sweep_params`` and the remaining columns are the values of the
         simulation identified by the ``outputs`` argument.
     """
+
+    deprecation_warning(
+        "parameter_sweep function is deprecated please call the ParameterSweep class instead.",
+        version="0.1.0",
+    )
 
     kwargs = {}
     if csv_results_file_name is not None:
@@ -283,6 +290,11 @@ def recursive_parameter_sweep(
         by ``sweep_params`` and the remaining columns are the values of the
         simulation identified by the ``outputs`` argument.
     """
+
+    deprecation_warning(
+        "recursive_parameter_sweep function is deprecated please call the RecursiveParameterSweep class instead.",
+        version="0.1.0",
+    )
 
     kwargs = {}
     if csv_results_file_name is not None:
@@ -453,6 +465,11 @@ def differential_parameter_sweep(
         by ``sweep_params`` and the remaining columns are the values of the
         simulation identified by the ``outputs`` argument.
     """
+
+    deprecation_warning(
+        "differential_parameter_sweep function is deprecated please call the DifferentialParameterSweep class instead.",
+        version="0.1.0",
+    )
 
     kwargs = {}
     kwargs["build_differential_sweep_specs"] = build_differential_sweep_specs

--- a/src/parameter_sweep/parameter_sweep.py
+++ b/src/parameter_sweep/parameter_sweep.py
@@ -809,8 +809,8 @@ class ParameterSweep(_ParameterSweepBase, _ParameterSweepParallelUtils):
             _model = build_model
             build_model = lambda: _model
             deprecation_warning(
-                "Passing a model directly to the parameter_sweep function is deprecated \
-                                and will not work with future implementations of parallelism.",
+                "Passing a model directly to the parameter_sweep function is deprecated "
+                "and will not work with future implementations of parallelism.",
                 version="0.10.0",
             )
 
@@ -818,8 +818,8 @@ class ParameterSweep(_ParameterSweepBase, _ParameterSweepParallelUtils):
             _sweep_params = build_sweep_params
             build_sweep_params = lambda model: _sweep_params
             deprecation_warning(
-                "Passing sweep params directly to the parameter_sweep function is deprecated \
-                                and will not work with future implementations of parallelism.",
+                "Passing sweep params directly to the parameter_sweep function is deprecated "
+                "and will not work with future implementations of parallelism.",
                 version="0.10.0",
             )
 
@@ -830,8 +830,8 @@ class ParameterSweep(_ParameterSweepBase, _ParameterSweepParallelUtils):
             _combined_outputs = build_outputs
             build_outputs = lambda model: _combined_outputs
             deprecation_warning(
-                "Passing the output dict directly to the parameter_sweep function is deprecated \
-                                and will not work with future implementations of parallelism.",
+                "Passing the output dict directly to the parameter_sweep function is deprecated "
+                "and will not work with future implementations of parallelism.",
                 version="0.10.0",
             )
         # This should be depreciated in future versions
@@ -984,8 +984,8 @@ class RecursiveParameterSweep(_ParameterSweepBase):
             _model = build_model
             build_model = lambda: _model
             deprecation_warning(
-                "Passing a model directly to the parameter_sweep function is deprecated \
-                                and will not work with future implementations of parallelism.",
+                "Passing a model directly to the parameter_sweep function is deprecated "
+                "and will not work with future implementations of parallelism.",
                 version="0.10.0",
             )
 
@@ -993,8 +993,8 @@ class RecursiveParameterSweep(_ParameterSweepBase):
             _sweep_params = build_sweep_params
             build_sweep_params = lambda model: _sweep_params
             deprecation_warning(
-                "Passing sweep params directly to the parameter_sweep function is deprecated \
-                                and will not work with future implementations of parallelism.",
+                "Passing sweep params directly to the parameter_sweep function is deprecated "
+                "and will not work with future implementations of parallelism.",
                 version="0.10.0",
             )
 
@@ -1005,8 +1005,8 @@ class RecursiveParameterSweep(_ParameterSweepBase):
             _combined_outputs = build_outputs
             build_outputs = lambda model: _combined_outputs
             deprecation_warning(
-                "Passing the output dict directly to the parameter_sweep function is deprecated \
-                                and will not work with future implementations of parallelism.",
+                "Passing the output dict directly to the parameter_sweep function is deprecated "
+                "and will not work with future implementations of parallelism.",
                 version="0.10.0",
             )
         # This should be depreciated in future versions


### PR DESCRIPTION
This PR:

1. Adds deprecation warnings for parameter sweep wrapper functions as they will be removed in future versions. 
2. Updates line breaks in existing deprecation warnings to prevent extra spaces in actual printed outputs.