### PR TITLE
New version of numpy causing issues with scalars and id arrays

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -109,7 +109,7 @@ jobs:
       - if: matrix.mpi
         name: Collect coverage for MPI-using code
         run: |
-          conda install --quiet --yes mpi4py
+          conda install mpi4py
           mpiexec -n 2 \
           coverage run --parallel-mode \
           -m mpi4py -m pytest \

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -62,10 +62,10 @@ jobs:
           - install-mode: dev
             python-version: "3.11"  # choice of Python version is arbitrary among those in matrix
             coverage: "true"
-          - install-mode: dev
+          - os: win64 # only run mpi, on windows, until GH starts working again. 
+            install-mode: dev
             python-version: "3.11"
             mpi: "true"
-
     steps:
       - if: matrix.install-mode == 'dev'
         uses: actions/checkout@v4

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -56,7 +56,7 @@ jobs:
           - win64
         include:
           - os: linux
-            os-version: ubuntu-24.04
+            os-version: ubuntu-22.04
           - os: win64
             os-version: windows-2022
           - install-mode: dev

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -56,7 +56,7 @@ jobs:
           - win64
         include:
           - os: linux
-            os-version: ubuntu-22.04
+            os-version: ubuntu-24.04
           - os: win64
             os-version: windows-2022
           - install-mode: dev

--- a/src/parameter_sweep/parameter_sweep.py
+++ b/src/parameter_sweep/parameter_sweep.py
@@ -1144,7 +1144,7 @@ class RecursiveParameterSweep(_ParameterSweepBase):
 
             # The total number of samples to generate at the next iteration is a multiple of the total remaining samples
             scale_factor = 2.0 / max(success_prob, 0.10)
-            num_total_samples = int(np.ceil(scale_factor * n_samples_remaining))
+            num_total_samples = int(np.ceil(scale_factor * n_samples_remaining).item())
 
         # Now that we have all of the local output dictionaries, we need to construct
         # a consolidated dictionary based on a filter, e.g., optimal solves.


### PR DESCRIPTION
the line `num_total_samples = int(np.ceil(scale_factor * n_samples_remaining))` causes an error in WaterTAP:

`FAILED tutorials/parameter_sweep_demo.ipynb::parameter_sweep_demo.ipynb - TypeError: only 0-dimensional arrays can be converted to Python scalars`

this is fixed if the item is pulled from `(scale_factor * n_samples_remaining)` before casting to an np.ceil is applied. 
